### PR TITLE
Handle empty comment lines

### DIFF
--- a/pkg/host/host_file.go
+++ b/pkg/host/host_file.go
@@ -89,7 +89,7 @@ func Read(r io.Reader, strict bool) (*hostFile, error) {
 func IsHostLine(line string) bool {
 	p := strings.Split(cleanLine(line), " ")
 	i := 0
-	if p[0] == "#" {
+	if p[0] == "#" && len(p) > 1 {
 		i = 1
 	}
 	ip := net.ParseIP(p[i])


### PR DESCRIPTION
Handles cases where the line is a single octothorp (`#`). In the case below:
```
#
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost
255.255.255.255	broadcasthost
::1             localhost
# Added by Docker Desktop
# To allow the same kube context to work on the host and the container:
127.0.0.1 kubernetes.docker.internal
# End of section
```

When `hostctl list` is run, it panics:
```
Using hosts file: /etc/hosts
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/guumaster/hostctl/pkg/host.IsHostLine(0x138b423, 0x1, 0x6)
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/pkg/host/host_file.go:95 +0xdc
github.com/guumaster/hostctl/pkg/host.appendProfile(0x1209322, 0x7, 0xc000156000, 0xc000126e00, 0xd, 0x10)
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/pkg/host/list.go:66 +0x95
github.com/guumaster/hostctl/pkg/host.ListProfiles(0x1209bb9, 0xa, 0xc00013bd78, 0x1209bb9, 0xa)
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/pkg/host/list.go:34 +0x260
github.com/guumaster/hostctl/cmd.glob..func9(0x13a0ca0, 0x13cdf38, 0x0, 0x0, 0x0, 0x0)
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/cmd/list.go:24 +0xd5
github.com/spf13/cobra.(*Command).execute(0x13a0ca0, 0x13cdf38, 0x0, 0x0, 0x13a0ca0, 0x13cdf38)
	/Users/gkontridze/Development/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:840 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0x13a1480, 0x0, 0x0, 0x0)
	/Users/gkontridze/Development/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:945 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/gkontridze/Development/go/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:885
github.com/guumaster/hostctl/cmd.Execute()
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/cmd/root.go:35 +0x2d
main.main()
	/Users/gkontridze/Development/go/pkg/mod/github.com/guumaster/hostctl@v0.3.0/main.go:10 +0x20
```