### PR TITLE
add autocompletion for bash and zsh

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generates bash completion scripts",
+}
+
+// completionZshCmd represents the completion command for zsh terminal
+var completionZshCmd = &cobra.Command{
+	Use:   "zsh",
+	Short: "Generates zsh completion scripts",
+	Long: `To load completion run
+
+source <(hostctl completion zsh)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.zshrc
+source <(hostctl completion bash)
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rootCmd.GenZshCompletion(os.Stdout)
+	},
+}
+
+// completionBashCmd represents the completion command for bash terminal
+var completionBashCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "Generates bash completion scripts",
+	Long: `To load completion run
+
+source <(hostctl completion bash)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+source <(hostctl completion bash)
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rootCmd.GenBashCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+	completionCmd.AddCommand(completionZshCmd, completionBashCmd)
+}


### PR DESCRIPTION
After reading Cobra guides I cannot make it work properly. 


[ZSH completion](https://github.com/spf13/cobra/blob/master/zsh_completions.md)
[BASH completion](https://github.com/spf13/cobra/blob/master/bash_completions.md)

Closes #29 
