### PR TITLE
Fix error massage typo

### DIFF
--- a/pkg/host/host_file.go
+++ b/pkg/host/host_file.go
@@ -203,7 +203,7 @@ func getHostData(dst, profile string) (*hostFile, error) {
 	}
 	_, ok := h.profiles[profile]
 	if profile != "" && !ok {
-		return h, fmt.Errorf("profile '%s' doesn't exists in file", profile)
+		return h, fmt.Errorf("unknown profile '%s'", profile)
 	}
 
 	return h, nil


### PR DESCRIPTION
`Error: profile 'awesome' doesn't exists in file` has a typo as it should be doesn't exist. But, the error message itself is not that comprehensible. 

Proposal to change it to `Error: unknown profile 'awesome'`.