### PR TITLE
fix zshrc typo

### DIFF
--- a/docs/content/docs/guides/auto_completion.md
+++ b/docs/content/docs/guides/auto_completion.md
@@ -15,7 +15,7 @@ source <(hostctl completion bash)
 
 ### Zsh
 
-Add this line on your `$HOME/.bashrc`
+Add this line on your `$HOME/.zshrc`
 
 ```
 source <(hostctl completion zsh)


### PR DESCRIPTION
fixes zsh file typo
`.bashrc` ==> `.zshrc`