### PR TITLE
Preventing comments from getting into entries

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -142,7 +142,7 @@ func parseProfileHeader(b []byte) (*types.Profile, error) {
 func parseRouteLine(str string) (*types.Route, bool) {
 	clean := spaceRemover.ReplaceAllString(str, " ")
 	clean = tabReplacer.ReplaceAllString(clean, " ")
-	clean = strings.TrimSpace(str)
+	clean = strings.TrimSpace(clean)
 	result := endingComment.FindStringSubmatch(clean)
 	tResult := strings.TrimSpace(result[1])
 	p := strings.Split(tResult, " ")

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -16,6 +16,7 @@ var (
 	profileEnd    = regexp.MustCompile(`(?i)# end\s*`)
 	spaceRemover  = regexp.MustCompile(`\s+`)
 	tabReplacer   = regexp.MustCompile(`\t+`)
+	endingComment = regexp.MustCompile(`(.[^#]*).*`)
 )
 
 // Parser is the interface for content parsers
@@ -141,9 +142,10 @@ func parseProfileHeader(b []byte) (*types.Profile, error) {
 func parseRouteLine(str string) (*types.Route, bool) {
 	clean := spaceRemover.ReplaceAllString(str, " ")
 	clean = tabReplacer.ReplaceAllString(clean, " ")
-	clean = strings.TrimSpace(clean)
-
-	p := strings.Split(clean, " ")
+	clean = strings.TrimSpace(str)
+	result := endingComment.FindStringSubmatch(clean)
+	tResult := strings.TrimSpace(result[1])
+	p := strings.Split(tResult, " ")
 
 	i := 0
 	if p[0] == "#" && len(p) > 1 {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -93,7 +93,8 @@ func TestParser(t *testing.T) {
 		}
 		appendLine(p, "127.0.0.1 first.loc")
 		appendLine(p, "127.0.0.1 second.loc")
-		assert.Len(t, p.Routes["127.0.0.1"].HostNames, 2)
+		appendLine(p, "127.0.0.1 third.loc # test comment")
+		assert.Len(t, p.Routes["127.0.0.1"].HostNames, 3)
 	})
 
 	t.Run("appendLine disabled", func(t *testing.T) {
@@ -102,7 +103,8 @@ func TestParser(t *testing.T) {
 			Routes: map[string]*types.Route{},
 		}
 		appendLine(p, "# 127.0.0.1 first.loc")
-		assert.Len(t, p.Routes["127.0.0.1"].HostNames, 1)
+		appendLine(p, "# 127.0.0.1 second.loc # test comment")
+		assert.Len(t, p.Routes["127.0.0.1"].HostNames, 2)
 	})
 
 	t.Run("appendLine invalid lines", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Pablo Caderno <kaderno@gmail.com>

Fixes issue #72 

I've also removed the spaceRemover and tabReplacer since `strings.TrimSpace()` should get rid of either of these.