### PR TITLE
Add instructions to install with asdf

### DIFF
--- a/docs/content/docs/installation.md
+++ b/docs/content/docs/installation.md
@@ -42,6 +42,12 @@ nix-env -iA nixpkgs.hostctl
 brew install guumaster/tap/hostctl
 ```
 
+### asdf
+
+```
+asdf plugin add hostctl https://github.com/svenluijten/asdf-hostctl.git
+asdf install hostctl latest
+```
 
 ### Scoop
 


### PR DESCRIPTION
[`asdf`](https://asdf-vm.com) is a version manager that uses the binaries directly from GitHub to install (mostly CLI) tools. I've gone ahead and [made a hostctl plugin](https://github.com/svenluijten/asdf-hostctl) so people can use and install `hostctl` with `asdf`. 

This PR adds the installation instructions for `asdf` to the docs, right above the deprecated Scoop and Snap options.